### PR TITLE
Update composer version to 2.0.9.

### DIFF
--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 ARG PHP_VERSION
 ARG COMPOSER_VERSION
-ARG PRESTISSIMO_VERSION
 
 RUN apt-get update --quiet \
     && apt-get upgrade --quiet --yes \
@@ -98,4 +97,3 @@ RUN chmod -R a+wrx /var/www/app
 RUN chmod  a+wrx /usr/local/bin/composer
 
 USER dev
-RUN composer global require --no-interaction --no-progress hirak/prestissimo:${PRESTISSIMO_VERSION}

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 ARG PHP_VERSION
 ARG COMPOSER_VERSION
-ARG PRESTISSIMO_VERSION
 
 RUN apt-get update --quiet \
     && apt-get upgrade --quiet --yes \
@@ -95,4 +94,3 @@ RUN chmod -R a+wrx /var/www/app
 RUN chmod  a+wrx /usr/local/bin/composer
 
 USER dev
-RUN composer global require --no-interaction --no-progress hirak/prestissimo:${PRESTISSIMO_VERSION}

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 ARG PHP_VERSION
 ARG COMPOSER_VERSION
-ARG PRESTISSIMO_VERSION
 
 RUN apt-get update --quiet \
     && apt-get upgrade --quiet --yes \
@@ -98,4 +97,3 @@ RUN chmod -R a+wrx /var/www/app
 RUN chmod  a+wrx /usr/local/bin/composer
 
 USER dev
-RUN composer global require --no-interaction --no-progress hirak/prestissimo:${PRESTISSIMO_VERSION}

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 ARG PHP_VERSION
 ARG COMPOSER_VERSION
-ARG PRESTISSIMO_VERSION
 
 RUN apt-get update --quiet \
     && apt-get upgrade --quiet --yes \
@@ -98,4 +97,3 @@ RUN chmod -R a+wrx /var/www/app
 RUN chmod  a+wrx /usr/local/bin/composer
 
 USER dev
-RUN composer global require --no-interaction --no-progress hirak/prestissimo:${PRESTISSIMO_VERSION}

--- a/build.yml
+++ b/build.yml
@@ -9,9 +9,8 @@ services:
       context: .
       args:
         - BUILD_DATE=$BUILD_DATE
-        - COMPOSER_VERSION=1.10.10
+        - COMPOSER_VERSION=2.0.9
         - PHP_VERSION=7.4
-        - PRESTISSIMO_VERSION=0.3.10
         - VCS_REF=$VCS_REF
   php7.3:
     image: ${COMPOSE_BUILD_NAME}:7.3
@@ -20,9 +19,8 @@ services:
       context: .
       args:
         - BUILD_DATE=$BUILD_DATE
-        - COMPOSER_VERSION=1.10.10
+        - COMPOSER_VERSION=2.0.9
         - PHP_VERSION=7.3
-        - PRESTISSIMO_VERSION=0.3.10
         - VCS_REF=$VCS_REF
   php7.2:
     image: ${COMPOSE_BUILD_NAME}:7.2
@@ -31,9 +29,8 @@ services:
       context: .
       args:
         - BUILD_DATE=$BUILD_DATE
-        - COMPOSER_VERSION=1.10.10
+        - COMPOSER_VERSION=2.0.9
         - PHP_VERSION=7.2
-        - PRESTISSIMO_VERSION=0.3.10
         - VCS_REF=$VCS_REF
   php7.1:
     image: ${COMPOSE_BUILD_NAME}:7.1
@@ -42,7 +39,6 @@ services:
       context: .
       args:
         - BUILD_DATE=$BUILD_DATE
-        - COMPOSER_VERSION=1.10.10
+        - COMPOSER_VERSION=2.0.9
         - PHP_VERSION=7.1
-        - PRESTISSIMO_VERSION=0.3.10
         - VCS_REF=$VCS_REF


### PR DESCRIPTION
This pull request update composer to version 2.0.9 (current latest) in all images.

It also removes Prestissimo that is not required anymore as per its author [here](https://github.com/hirak/prestissimo#announcement-composer-2-is-now-available).